### PR TITLE
Add testcases for findtasks command.

### DIFF
--- a/src/test/java/seedu/address/logic/parser/FindTasksCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTasksCommandParserTest.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindTasksCommand;
+import seedu.address.model.task.TaskNameContainsKeywordsPredicate;
+
+public class FindTasksCommandParserTest {
+
+    private FindTasksCommandParser parser = new FindTasksCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindTasksCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindTasksCommand() {
+        // no leading and trailing whitespaces
+        FindTasksCommand expectedFindTasksCommand =
+                new FindTasksCommand(new TaskNameContainsKeywordsPredicate(Arrays.asList("project", "meeting")));
+        assertParseSuccess(parser, "project meeting", expectedFindTasksCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n project \n \t meeting  \t", expectedFindTasksCommand);
+    }
+
+}
+

--- a/src/test/java/seedu/address/model/task/TaskNameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/TaskNameContainsKeywordsPredicateTest.java
@@ -1,0 +1,90 @@
+package seedu.address.model.task;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+
+public class TaskNameContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("project");
+        List<String> secondPredicateKeywordList = Arrays.asList("project", "meeting");
+
+        TaskNameContainsKeywordsPredicate firstPredicate =
+                new TaskNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        TaskNameContainsKeywordsPredicate secondPredicate =
+                new TaskNameContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TaskNameContainsKeywordsPredicate firstPredicateCopy =
+                new TaskNameContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different employee -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_taskNameContainsKeywords_returnsTrue() {
+        Task testTask = new Task(new TaskName("project meeting"), new TaskId(2), new TaskStatus(false),
+                new AssignedEmployees(""));
+        // One keyword
+        TaskNameContainsKeywordsPredicate predicate =
+                new TaskNameContainsKeywordsPredicate(Collections.singletonList("project"));
+        assertTrue(predicate.test(testTask));
+
+        // Multiple keywords
+        predicate = new TaskNameContainsKeywordsPredicate(Arrays.asList("project", "meeting"));
+        assertTrue(predicate.test(testTask));
+
+        // Only one matching keyword
+        predicate = new TaskNameContainsKeywordsPredicate(Arrays.asList("project"));
+        assertTrue(predicate.test(testTask));
+
+        // Mixed-case keywords
+        predicate = new TaskNameContainsKeywordsPredicate(Arrays.asList("pRoJEct", "mEeTing"));
+        assertTrue(predicate.test(testTask));
+    }
+    @Test
+    public void test_nameDoesNotContainKeywords_returnsFalse() {
+        Task testTask = new Task(new TaskName("project meeting"), new TaskId(2), new TaskStatus(false),
+                new AssignedEmployees("John"));
+        // Zero keywords
+        TaskNameContainsKeywordsPredicate predicate = new TaskNameContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(testTask));
+
+        // Non-matching keyword
+        predicate = new TaskNameContainsKeywordsPredicate(List.of("assignment"));
+        assertFalse(predicate.test(testTask));
+
+        // Keywords match TaskId, TaskStatus and AssignedEmployees, but does not match TaskName
+        predicate = new TaskNameContainsKeywordsPredicate(Arrays.asList("2", "In", "Progress", "John"));
+        assertFalse(predicate.test(testTask));
+    }
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        TaskNameContainsKeywordsPredicate predicate = new TaskNameContainsKeywordsPredicate(keywords);
+
+        String expected = TaskNameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}
+


### PR DESCRIPTION
FindTasksCommandParser and the predicate for findtasks have been tested. The FindTasksCommand have not been tested yet because the getTypicalTaskMasterPro() currently does not include pre-build tasks.