### PR TITLE
remove outdated seq diagram

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -455,12 +455,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2/4.
 
-![Interactions Inside the Logic Component for the `assigntask 1 6` Command](images/AssignTaskSequenceDiagram.png)
-![Interactions for updating existing employee fields for the `assign 1 6` command](images/AssignTaskRefSequenceDiagram.png)
-<br>
-Note that if none of the taskId == 1, an invalid taskId exception will be thrown.
-If none of the employeeId == 6, an invalid employeeId exception will be thrown.
-
 **Use case: Mark a task as done**
 
 **MSS**


### PR DESCRIPTION
This outdated sequence diagram for assigntasks  was created before the hashtable was implemented so I am deleting it from the DG now. It was previously under the use case for assigntasks.