### PR TITLE
Fix issue #167

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -10,6 +10,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_EMPLOYEES;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -29,6 +30,7 @@ import seedu.address.model.employee.EmployeeId;
 import seedu.address.model.employee.Name;
 import seedu.address.model.employee.Phone;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Task;
 
 /**
  * Edits the details of an existing employee in TaskMasterPro.
@@ -95,7 +97,23 @@ public class EditCommand extends Command {
 
         model.setEmployee(employeeToEdit, editedEmployee);
         model.updateFilteredEmployeeList(PREDICATE_SHOW_ALL_EMPLOYEES);
-        return new CommandResult(String.format(MESSAGE_EDIT_EMPLOYEE_SUCCESS, Messages.format(editedEmployee)));
+
+        //This section will update all the assigned tasks so that each task will refer to the new employee
+        model.updateFilteredTaskList(Model.PREDICATE_SHOW_ALL_TASKS);
+        List<Task> taskList = model.getFilteredTaskList();
+        Hashtable<Integer, Task> assignedTasks = editedEmployee.getTasks().getAssignedTasks();
+        for (Integer key : assignedTasks.keySet()) {
+            for (Task t : taskList) {
+                if (t.getTaskId() == key) {
+                    t.getEmployees().unassignEmployee(editedEmployee.getEmployeeId());
+                    t.getEmployees().assignEmployee(editedEmployee);
+                    break;
+                }
+            }
+        }
+
+        return new CommandResult(String.format(MESSAGE_EDIT_EMPLOYEE_SUCCESS, Messages.format(editedEmployee)),
+                false, true, false, false);
     }
 
     /**


### PR DESCRIPTION
The edit command will now also iterate through all the assigned tasks of
the edited employee. For each of this tasks, iterate through all the
tasks in the model and look for the task itself.

After this then access the assigned employees of each of those tasks and
remove and re add this new edited employee.

This has to be done because the assigned employees and assigned tasks
contains an immutable object of task or employee that is not the same as the one stored in
the main model object for the app. This is why the error happens to
begin with.